### PR TITLE
fix(hotkey): allow extra characters in hotkey state

### DIFF
--- a/Client/HotkeyManager/hotkey_state.py
+++ b/Client/HotkeyManager/hotkey_state.py
@@ -7,6 +7,9 @@ from Utility import get_logger
 logger = get_logger(__name__)
 
 
+EXTRA_ACTIVE_CHARACTERS = "',./-+*"
+
+
 @dataclass
 class HotkeyState:
     """Состояние отслеживания клавиш. Хранит в себе текущие нажатые клавиши"""
@@ -18,7 +21,7 @@ class HotkeyState:
         logger.debug(f"Добавлена клавиша {key} ({type(key)}), текущее состояние: {self.pressed_keys}")
         if isinstance(key, keyboard.KeyCode) and key.char:
             # Скипаем управляющие символы (Ctrl+A и т.д.)
-            if not key.char.isalnum() or key.char.isupper():
+            if not key.char.isalnum() or key.char.isupper() or key.char not in EXTRA_ACTIVE_CHARACTERS:
                 logger.debug(f"Skipped {key.char=}")
                 return
 

--- a/GUIClient/Widgets/hotkey_edit.py
+++ b/GUIClient/Widgets/hotkey_edit.py
@@ -53,6 +53,7 @@ class HotkeyEdit(QKeySequenceEdit):
         
         extra_solo_keys = [Qt.Key.Key_Alt, Qt.Key.Key_Control, Qt.Key.Key_Shift]
         
+        exception_key = None
         if key in extra_solo_keys:
             if sys.platform == 'win32':
                 native_key = event.nativeScanCode()
@@ -60,13 +61,11 @@ class HotkeyEdit(QKeySequenceEdit):
                 logger.debug(f"{key=}, {native_key=}")
                 
                 if native_key in [56, 57400]:
-                    exception_key = None
                     # ALT
                     if native_key == 56:
                         exception_key = "alt_l"
                     elif native_key == 57400:
                         exception_key = "alt_gr"
-                    self.exception_key = exception_key
                     self._setDisplayText(SPECIAL_KEY_DISPLAY[exception_key]) # type: ignore
                 else:
                     self.setKeySequence(QKeySequence(key))
@@ -77,6 +76,8 @@ class HotkeyEdit(QKeySequenceEdit):
             event.accept()
         else:
             super().keyPressEvent(event)
+        
+        self.exception_key = exception_key
     
     def get_hotkey_string(self) -> str:
         """Получить строковое представление горячей клавиши"""


### PR DESCRIPTION
This change fixes two issues:
1. Hotkey state now allows extra characters (',', '.', '/', '-', '+', '*') to be used in hotkeys, which were previously skipped.
2. The hotkey edit widget now correctly handles exception keys by initializing the exception_key variable and setting the instance attribute after the condition.